### PR TITLE
Ignore updates for @vitest/browser dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@vitest/browser"
+        


### PR DESCRIPTION
Configure Dependabot to ignore updates for the @vitest/browser package.